### PR TITLE
Add $PARAM_TYPES support (only on creation and not for update)

### DIFF
--- a/CommentCompletion/DoxygenCompletionHandler.cs
+++ b/CommentCompletion/DoxygenCompletionHandler.cs
@@ -549,7 +549,7 @@ namespace DoxygenComments
                             CodeParameter parameter = child as CodeParameter;
                             if (parameter != null)
                             {
-                                sb.AppendFormat(match.Value.Replace("$PARAMS", parameter.Name) + "\n");
+                                sb.AppendFormat(match.Value.Replace("$PARAMS", parameter.Name).Replace("$PARAM_TYPES", parameter.Type.AsString) + "\n");
                             }
                         }
                         format = ReplaceLineWith(format, match.Value, sb.ToString());
@@ -615,7 +615,7 @@ namespace DoxygenComments
             format = Regex.Replace(format, @"(\r\n)|(\r|\n)", lineEnding + spaces);
 
             // Replace all variables with the correct values
-            // Specififc variables like $PARAMS and $RETURN must be handled before in
+            // Specific variables like $PARAMS, $PARAM_TYPES and $RETURN must be handled before in
             // a function specific part
             if (format.Contains("$BRIEF"))
             {

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ and the `\return` attribute will only be shown without a void return type.
 You can replace attributes like `\param` or `\return` with everything else (for example: `@param`), 
 if you use the `$PARAMS` and `$RETURN` variables in the same line.
 
+`$PARAM_TYPES` only works with `$PARAMS` on the same line.
+
 To use the `$` character as plain text in your comment you can escape ith with `\`  (e.g. `\$id` will be shown as `$id` in the comment)
 
 If you want you can add custom attributes like `\license` to always generate a licence in a header comment.

--- a/Settings/DoxygenToolsOptionsBase.Designer.cs
+++ b/Settings/DoxygenToolsOptionsBase.Designer.cs
@@ -75,7 +75,7 @@ namespace DoxygenComments.Settings {
         ///   Looks up a localized string similar to /**
         /// * $BRIEF$END.
         /// * 
-        /// * \param $PARAMS
+        /// * \param $PARAMS [$PARAM_TYPES]
         /// * \return $RETURN
         /// */.
         /// </summary>

--- a/Settings/DoxygenToolsOptionsBase.resx
+++ b/Settings/DoxygenToolsOptionsBase.resx
@@ -126,7 +126,7 @@
     <value>/**
  * $BRIEF$END.
  * 
- * \param $PARAMS
+ * \param $PARAMS [$PARAM_TYPES]
  * \return $RETURN
  */</value>
   </data>

--- a/Settings/DoxygenToolsOptionsControl.resx
+++ b/Settings/DoxygenToolsOptionsControl.resx
@@ -127,6 +127,7 @@ To escape a variable or a '$' in general use the back slash '\'.
 
 You can use following variables:
 $PARAMS
+$PARAM_TYPES
 $RETURN
 $BRIEF
 $MONTH


### PR DESCRIPTION
By adding $PARAM_TYPES in the same line of $PARAMS, we can have documentation like this

```
* @param aElementList [std::vector<int>]
* @param aElement [int]`
```

For the moment, the update doesn't work